### PR TITLE
improve disk usage of zap

### DIFF
--- a/build.go
+++ b/build.go
@@ -22,7 +22,7 @@ import (
 	"github.com/couchbase/vellum"
 )
 
-const Version uint32 = 12
+const Version uint32 = 13
 
 const Type string = "zap"
 

--- a/build.go
+++ b/build.go
@@ -16,6 +16,7 @@ package zap
 
 import (
 	"bufio"
+	"math"
 	"os"
 
 	"github.com/couchbase/vellum"
@@ -25,11 +26,7 @@ const Version uint32 = 13
 
 const Type string = "zap"
 
-// We can safely use 0 to represent fieldNotUninverted since 0
-// could never be a valid address for doc values start/end.
-// (stored field index is always non-empty and earlier in the
-// file)
-const fieldNotUninverted = 0
+const fieldNotUninverted = math.MaxUint64
 
 func (sb *SegmentBase) Persist(path string) error {
 	return PersistSegmentBase(sb, path)

--- a/build.go
+++ b/build.go
@@ -16,7 +16,6 @@ package zap
 
 import (
 	"bufio"
-	"math"
 	"os"
 
 	"github.com/couchbase/vellum"
@@ -26,7 +25,11 @@ const Version uint32 = 13
 
 const Type string = "zap"
 
-const fieldNotUninverted = math.MaxUint64
+// We can safely use 0 to represent fieldNotUninverted since 0
+// could never be a valid address for doc values start/end.
+// (stored field index is always non-empty and earlier in the
+// file)
+const fieldNotUninverted = 0
 
 func (sb *SegmentBase) Persist(path string) error {
 	return PersistSegmentBase(sb, path)

--- a/cmd/zap/cmd/dict.go
+++ b/cmd/zap/cmd/dict.go
@@ -20,7 +20,7 @@ import (
 	"math"
 
 	"github.com/RoaringBitmap/roaring"
-	"github.com/blevesearch/zap/v12"
+	"github.com/blevesearch/zap/v13"
 	"github.com/couchbase/vellum"
 	"github.com/spf13/cobra"
 )

--- a/cmd/zap/cmd/docvalue.go
+++ b/cmd/zap/cmd/docvalue.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/blevesearch/zap/v12"
+	"github.com/blevesearch/zap/v13"
 	"github.com/golang/snappy"
 	"github.com/spf13/cobra"
 )

--- a/cmd/zap/cmd/docvalue.go
+++ b/cmd/zap/cmd/docvalue.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"log"
+	"math"
 	"sort"
 	"strconv"
 
@@ -26,8 +27,6 @@ import (
 	"github.com/golang/snappy"
 	"github.com/spf13/cobra"
 )
-
-const fieldNotUninverted = 0
 
 // docvalueCmd represents the docvalue command
 var docvalueCmd = &cobra.Command{
@@ -94,7 +93,7 @@ var docvalueCmd = &cobra.Command{
 			}
 
 			read += uint64(n)
-			if fieldStartLoc == fieldNotUninverted && len(args) == 1 {
+			if fieldStartLoc == math.MaxUint64 && len(args) == 1 {
 				fmt.Printf("FieldID: %d '%s' docvalue at %d (%x) not "+
 					" persisted \n", id, field, fieldStartLoc, fieldStartLoc)
 				continue
@@ -217,7 +216,7 @@ var docvalueCmd = &cobra.Command{
 		curChunkData := data[compressedDataLoc : compressedDataLoc+dataLength]
 
 		start, end = getDocValueLocs(uint64(localDocNum), curChunkHeader)
-		if start == fieldNotUninverted || end == fieldNotUninverted {
+		if start == math.MaxUint64 || end == math.MaxUint64 {
 			fmt.Printf("No field values found for localDocNum: %d\n",
 				localDocNum)
 			fmt.Printf("Try docNums present in chunk: %s\n",
@@ -257,7 +256,7 @@ func getDocValueLocs(docNum uint64, metaHeader []zap.MetaData) (uint64, uint64) 
 	if i < len(metaHeader) && metaHeader[i].DocNum == docNum {
 		return zap.ReadDocValueBoundary(i, metaHeader)
 	}
-	return fieldNotUninverted, fieldNotUninverted
+	return math.MaxUint64, math.MaxUint64
 }
 
 func metaDataDocNums(metaHeader []zap.MetaData) string {

--- a/cmd/zap/cmd/docvalue.go
+++ b/cmd/zap/cmd/docvalue.go
@@ -19,7 +19,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"log"
-	"math"
 	"sort"
 	"strconv"
 
@@ -27,6 +26,8 @@ import (
 	"github.com/golang/snappy"
 	"github.com/spf13/cobra"
 )
+
+const fieldNotUninverted = 0
 
 // docvalueCmd represents the docvalue command
 var docvalueCmd = &cobra.Command{
@@ -93,7 +94,7 @@ var docvalueCmd = &cobra.Command{
 			}
 
 			read += uint64(n)
-			if fieldStartLoc == math.MaxUint64 && len(args) == 1 {
+			if fieldStartLoc == fieldNotUninverted && len(args) == 1 {
 				fmt.Printf("FieldID: %d '%s' docvalue at %d (%x) not "+
 					" persisted \n", id, field, fieldStartLoc, fieldStartLoc)
 				continue
@@ -216,7 +217,7 @@ var docvalueCmd = &cobra.Command{
 		curChunkData := data[compressedDataLoc : compressedDataLoc+dataLength]
 
 		start, end = getDocValueLocs(uint64(localDocNum), curChunkHeader)
-		if start == math.MaxUint64 || end == math.MaxUint64 {
+		if start == fieldNotUninverted || end == fieldNotUninverted {
 			fmt.Printf("No field values found for localDocNum: %d\n",
 				localDocNum)
 			fmt.Printf("Try docNums present in chunk: %s\n",
@@ -256,7 +257,7 @@ func getDocValueLocs(docNum uint64, metaHeader []zap.MetaData) (uint64, uint64) 
 	if i < len(metaHeader) && metaHeader[i].DocNum == docNum {
 		return zap.ReadDocValueBoundary(i, metaHeader)
 	}
-	return math.MaxUint64, math.MaxUint64
+	return fieldNotUninverted, fieldNotUninverted
 }
 
 func metaDataDocNums(metaHeader []zap.MetaData) string {

--- a/cmd/zap/cmd/explore.go
+++ b/cmd/zap/cmd/explore.go
@@ -20,7 +20,7 @@ import (
 	"math"
 
 	"github.com/RoaringBitmap/roaring"
-	"github.com/blevesearch/zap/v12"
+	"github.com/blevesearch/zap/v13"
 	"github.com/couchbase/vellum"
 	"github.com/spf13/cobra"
 )

--- a/cmd/zap/cmd/explore.go
+++ b/cmd/zap/cmd/explore.go
@@ -25,8 +25,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const termNotEncoded = 0
-
 // exploreCmd represents the explore command
 var exploreCmd = &cobra.Command{
 	Use:   "explore [path] [field] <term> <docNum>",
@@ -111,7 +109,7 @@ var exploreCmd = &cobra.Command{
 						running += offset
 					}
 
-					if locAddr != termNotEncoded {
+					if locAddr != math.MaxUint64 {
 						fmt.Printf("Loc details at: %d (%x)\n", locAddr, locAddr)
 						numLChunks, r4 := binary.Uvarint(data[locAddr : locAddr+binary.MaxVarintLen64])
 						n = uint64(r4)

--- a/cmd/zap/cmd/explore.go
+++ b/cmd/zap/cmd/explore.go
@@ -25,6 +25,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const termNotEncoded = 0
+
 // exploreCmd represents the explore command
 var exploreCmd = &cobra.Command{
 	Use:   "explore [path] [field] <term> <docNum>",
@@ -109,7 +111,7 @@ var exploreCmd = &cobra.Command{
 						running += offset
 					}
 
-					if locAddr != math.MaxUint64 {
+					if locAddr != termNotEncoded {
 						fmt.Printf("Loc details at: %d (%x)\n", locAddr, locAddr)
 						numLChunks, r4 := binary.Uvarint(data[locAddr : locAddr+binary.MaxVarintLen64])
 						n = uint64(r4)

--- a/cmd/zap/cmd/fields.go
+++ b/cmd/zap/cmd/fields.go
@@ -18,7 +18,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/blevesearch/zap/v12"
+	"github.com/blevesearch/zap/v13"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/zap/cmd/root.go
+++ b/cmd/zap/cmd/root.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/blevesearch/zap/v12"
+	"github.com/blevesearch/zap/v13"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/zap/main.go
+++ b/cmd/zap/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/blevesearch/zap/v12/cmd/zap/cmd"
+	"github.com/blevesearch/zap/v13/cmd/zap/cmd"
 )
 
 func main() {

--- a/docvalues.go
+++ b/docvalues.go
@@ -203,7 +203,7 @@ func (di *docValueReader) visitDocValues(docNum uint64,
 	visitor index.DocumentFieldTermVisitor) error {
 	// binary search the term locations for the docNum
 	start, end := di.getDocValueLocs(docNum)
-	if start == fieldNotUninverted || end == fieldNotUninverted || start == end {
+	if start == math.MaxUint64 || end == math.MaxUint64 || start == end {
 		return nil
 	}
 
@@ -243,7 +243,7 @@ func (di *docValueReader) getDocValueLocs(docNum uint64) (uint64, uint64) {
 	if i < len(di.curChunkHeader) && di.curChunkHeader[i].DocNum == docNum {
 		return ReadDocValueBoundary(i, di.curChunkHeader)
 	}
-	return fieldNotUninverted, fieldNotUninverted
+	return math.MaxUint64, math.MaxUint64
 }
 
 // VisitDocumentFieldTerms is an implementation of the

--- a/docvalues.go
+++ b/docvalues.go
@@ -203,7 +203,7 @@ func (di *docValueReader) visitDocValues(docNum uint64,
 	visitor index.DocumentFieldTermVisitor) error {
 	// binary search the term locations for the docNum
 	start, end := di.getDocValueLocs(docNum)
-	if start == math.MaxUint64 || end == math.MaxUint64 || start == end {
+	if start == fieldNotUninverted || end == fieldNotUninverted || start == end {
 		return nil
 	}
 
@@ -243,7 +243,7 @@ func (di *docValueReader) getDocValueLocs(docNum uint64) (uint64, uint64) {
 	if i < len(di.curChunkHeader) && di.curChunkHeader[i].DocNum == docNum {
 		return ReadDocValueBoundary(i, di.curChunkHeader)
 	}
-	return math.MaxUint64, math.MaxUint64
+	return fieldNotUninverted, fieldNotUninverted
 }
 
 // VisitDocumentFieldTerms is an implementation of the

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/blevesearch/zap/v12
+module github.com/blevesearch/zap/v13
 
 go 1.12
 

--- a/intcoder.go
+++ b/intcoder.go
@@ -18,10 +18,13 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"math"
 )
 
-const termNotEncoded = math.MaxUint64
+// We can safely use 0 to represent termNotEncoded since 0
+// could never be a valid address for term location information.
+// (stored field index is always non-empty and earlier in the
+// file)
+const termNotEncoded = 0
 
 type chunkedIntCoder struct {
 	final     []byte


### PR DESCRIPTION
Breaking change, to be released as new major version (v13.0.0)

One of the optimizations in v12 was to encode a special marker
value when a field/term had no location information stored.
Unfortunately that marker was math.MaxUint64, which when
encoded via Uvarint requires 10 bytes.  In practice, the number
of bytes required went up, not down as a result of this change.

Now, we use 0 as that special marker value.  This has been
determined to be safe as 0 could never be the actual address
of term location information, as there are other mandatory
sections earlier in the file (stored field index).