### PR TITLE
improve zap chunking

### DIFF
--- a/build.go
+++ b/build.go
@@ -22,7 +22,7 @@ import (
 	"github.com/couchbase/vellum"
 )
 
-const Version uint32 = 13
+const Version uint32 = 14
 
 const Type string = "zap"
 

--- a/cmd/zap/cmd/dict.go
+++ b/cmd/zap/cmd/dict.go
@@ -20,7 +20,7 @@ import (
 	"math"
 
 	"github.com/RoaringBitmap/roaring"
-	"github.com/blevesearch/zap/v13"
+	"github.com/blevesearch/zap/v14"
 	"github.com/couchbase/vellum"
 	"github.com/spf13/cobra"
 )

--- a/cmd/zap/cmd/docvalue.go
+++ b/cmd/zap/cmd/docvalue.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/blevesearch/zap/v13"
+	"github.com/blevesearch/zap/v14"
 	"github.com/golang/snappy"
 	"github.com/spf13/cobra"
 )

--- a/cmd/zap/cmd/explore.go
+++ b/cmd/zap/cmd/explore.go
@@ -20,7 +20,7 @@ import (
 	"math"
 
 	"github.com/RoaringBitmap/roaring"
-	"github.com/blevesearch/zap/v13"
+	"github.com/blevesearch/zap/v14"
 	"github.com/couchbase/vellum"
 	"github.com/spf13/cobra"
 )

--- a/cmd/zap/cmd/fields.go
+++ b/cmd/zap/cmd/fields.go
@@ -18,7 +18,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/blevesearch/zap/v13"
+	"github.com/blevesearch/zap/v14"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/zap/cmd/root.go
+++ b/cmd/zap/cmd/root.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/blevesearch/zap/v13"
+	"github.com/blevesearch/zap/v14"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/zap/main.go
+++ b/cmd/zap/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/blevesearch/zap/v13/cmd/zap/cmd"
+	"github.com/blevesearch/zap/v14/cmd/zap/cmd"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/blevesearch/zap/v13
+module github.com/blevesearch/zap/v14
 
 go 1.12
 


### PR DESCRIPTION
chunk mode 1025 made singinifcant improvement for indexes
with many unique fields (or very low cardinality)

here we introduce chunk mode 1026 which takes the same
approach as 1025, but extends it to improve chunking for
all other cardinalities

specifically, we try to create the fewest number of dense chunks
chunk size is capped at 1024 documents as before