### PR TITLE
Fix the chunkSize initialisations

### DIFF
--- a/posting.go
+++ b/posting.go
@@ -277,8 +277,8 @@ func (rv *PostingsList) read(postingsOffset uint64, d *Dictionary) error {
 		return fmt.Errorf("error loading roaring bitmap: %v", err)
 	}
 
-	rv.chunkSize, err = getChunkSize(rv.sb.chunkMode,
-		rv.postings.GetCardinality(), rv.sb.numDocs)
+	rv.chunkSize, err = getChunkSize(d.sb.chunkMode,
+		rv.postings.GetCardinality(), d.sb.numDocs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Directly use the given dictionary for accessing the segmentBase
as there are access paths where the segmentBase entry for the
postings could be nil. It happens with the initialisations of
iterators like PrefixIterator, OnlyIterator..