### PR TITLE
 Restore the mergeTermFreqNormLocsByCopying optimisation

### DIFF
--- a/intDecoder.go
+++ b/intDecoder.go
@@ -105,6 +105,10 @@ func (d *chunkedIntDecoder) readUvarint() (uint64, error) {
 	return d.r.ReadUvarint()
 }
 
+func (d *chunkedIntDecoder) readBytes(start, end int) []byte {
+	return d.curChunkBytes[start:end]
+}
+
 func (d *chunkedIntDecoder) SkipUvarint() {
 	d.r.SkipUvarint()
 }
@@ -115,4 +119,8 @@ func (d *chunkedIntDecoder) SkipBytes(count int) {
 
 func (d *chunkedIntDecoder) Len() int {
 	return d.r.Len()
+}
+
+func (d *chunkedIntDecoder) remainingLen() int {
+	return len(d.curChunkBytes) - d.r.Len()
 }


### PR DESCRIPTION
 Even with custom or different chunk size/factors, it still
 looks safe and efficient to copy the freq,norm,locs bytes
 for saving the extra encodings of many uvarint's.

 Chunk factor differences across postings per segment
 doesn't look to affect the functionality here.

 By restoring this optimization, the performance of the merge
 paths improved.  QPS improvements are,

    wildcard - 30%
    fuzzy2 - 34%

 for showfast tests.
 ref - https://issues.couchbase.com/browse/MB-41399